### PR TITLE
Fix match category

### DIFF
--- a/front/src/containers/Match/MatchCreate/MatchCreate.js
+++ b/front/src/containers/Match/MatchCreate/MatchCreate.js
@@ -23,11 +23,11 @@ class MatchCreate extends Component {
   constructor(props) {
     super(props);
     // using category : not implemented
-    const { title, additionalInfo } = this.props;
+    const { title, additionalInfo, category } = this.props;
     this.state = {
       title,
       // matchThumbnail
-      category: null,
+      category,
       capacity: 2,
       locationText: '',
       locationLatitude: 37.4494771,
@@ -112,18 +112,19 @@ class MatchCreate extends Component {
 MatchCreate.propTypes = {
   onCreate: PropTypes.func.isRequired,
   history: ReactRouterPropTypes.history.isRequired,
-  // category: PropTypes.string.isRequired,
+  category: PropTypes.arrayOf(PropTypes.number),
   title: PropTypes.string,
   additionalInfo: PropTypes.string,
 };
 
 MatchCreate.defaultProps = {
   title: '',
+  category: null,
   additionalInfo: '',
 };
 const mapStateToProps = state => {
   return {
-    // category: state.match.category,
+    category: state.match.category,
     title: state.match.title,
     additionalInfo: state.match.additionalInfo,
   };

--- a/front/src/store/actions/match.js
+++ b/front/src/store/actions/match.js
@@ -3,6 +3,7 @@ import { push } from 'connected-react-router';
 import { message } from 'antd';
 import moment from 'moment';
 import * as actionTypes from './actionTypes';
+import { categories } from '../staticData/categories';
 
 axios.defaults.xsrfCookieName = 'csrftoken';
 axios.defaults.xsrfHeaderName = 'X-CSRFTOKEN';
@@ -191,10 +192,23 @@ export const createMatch = match => {
   };
 };
 
+const convertCategoryToArray = string => {
+  const splited = string.substring(1).split('/');
+
+  const CToACallback = (acc, ctgn) => {
+    const { ctgs, arr } = acc;
+    const target = ctgs.filter(obj => obj.label === ctgn)[0];
+    return { ctgs: target.children, arr: arr.concat([target.value]) };
+  };
+
+  const result = splited.reduce(CToACallback, { ctgs: categories, arr: [] });
+  return result.arr;
+};
+
 const sendNlpTextAction = (category, location, title, nlpText) => {
   return {
     type: actionTypes.SEND_NLP_TEXT,
-    category,
+    category: convertCategoryToArray(category),
     location,
     title,
     additionalInfo: nlpText,

--- a/front/src/store/actions/match.test.js
+++ b/front/src/store/actions/match.test.js
@@ -295,7 +295,7 @@ describe('ActionMatch', () => {
         const result = {
           status: 200,
           data: {
-            categories: [{ name: 'category' }],
+            categories: [{ name: '/Adult' }],
             locations: [{ name: 'location' }],
             events: [{ name: 'event' }],
           },
@@ -308,7 +308,7 @@ describe('ActionMatch', () => {
       .mockImplementation(path => path);
     store.dispatch(actionCreators.sendNlpText('analyze this')).then(() => {
       const newState = store.getState();
-      expect(newState.match.category).toBe('category');
+      expect(newState.match.category).toStrictEqual([0]);
       expect(newState.match.location).toBe('location');
       expect(newState.match.title).toBe('event');
       expect(spyPost).toHaveBeenCalledTimes(1);

--- a/front/src/store/reducers/matchReducer.js
+++ b/front/src/store/reducers/matchReducer.js
@@ -8,7 +8,7 @@ const initialState = {
   selected: undefined,
   // the following may not be needed
   myMatch: [],
-  category: '',
+  category: null,
   location: '',
   title: '',
   additionalInfo: '',


### PR DESCRIPTION
Category will be automatically set after NLP while creating match

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Backend로부터 category text가 오면, static data에 맞도록 파싱 후 create화면에서 정상적으로 보이도록 array로 변환하여 redux storage에 저장.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
